### PR TITLE
np.int deprecated

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(int) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(int)
         return X_orig
 
 


### PR DESCRIPTION
np.int is deprecated since 1.20.0 version of numPy, therefore these two lines must be updated.